### PR TITLE
Fixed bug in SettingsPage wre: canceling a save

### DIFF
--- a/src/components/CustomFormControl/CustomFormControlSetting.js
+++ b/src/components/CustomFormControl/CustomFormControlSetting.js
@@ -73,8 +73,11 @@ const CustomFormControlSetting = ({
     onChange: (e) => handleOnChange(e.target.value),
   });
 
+  /* Each time a default value comes through as a prop,
+  reset this component's value to that, and set diff to false */
   useEffect(() => {
     setValue(initialValue);
+    setDiff(false);
   }, [initialValue]);
 
   const handleOnChange = (val) => {
@@ -94,7 +97,6 @@ const CustomFormControlSetting = ({
   const handleOnSave = () => {
     if (id !== null) {
       onSave(id, value);
-      setDiff(false);
     }
   };
 
@@ -133,29 +135,6 @@ const CustomFormControlSetting = ({
       </Grid>
     </Grid>
   );
-  /* return (
-    <Grid container className={clsx(classes.root, { [classes.unsaved]: diff })}>
-      <Zoom in={diff} disableStrictModeCompat={true} timeout={300}>
-        <Grid item className={classes.gridForSaveButton}>
-          <IconButton
-            onClick={handleOnSave}
-            color="primary"
-            className={classes.saveIconButton}
-          >
-            <SaveIcon />
-          </IconButton>
-        </Grid>
-      </Zoom>
-      <Grid item className={classes.gridForInput}>
-        {label}
-        {initialValue}
-        {cloneElement(children, {
-          value: value,
-          onChange: (e) => handleOnChange(e.target.value),
-        })}
-      </Grid>
-    </Grid>
-  ); */
 };
 
 export default CustomFormControlSetting;

--- a/src/pages/SettingsPage/index.js
+++ b/src/pages/SettingsPage/index.js
@@ -112,11 +112,9 @@ const SettingsPage = () => {
   /* Get GridData and BedLayout from context */
   const { bedLayout, gridData, updateGridData } = useGridStateContext();
 
-  const [contingencyOptions, setContingencyOptions] = useState(
-    settings.contingencyOptions ? settings.contingencyOptions : null
-  );
+  const contingencyOptions = settings.contingencyOptions || [];
 
-  /* Import .json functionality */
+  /* Our import .json functionality */
   const [pendingDataImport, setPendingDataImport] = useState(null);
   const [confirmedDataImport, setConfirmedDataImport] = useState(false);
 


### PR DESCRIPTION
1. Fixed how CustomFormControlSetting handles diff. Now, even if save action is cancelled i.e. after dialog, the diff is not changed (It should only be changed if the save action is completed and a new initialValue prop is passed through)
2. Small edit to SettingsPage prop - deleted a state variable that was redundant